### PR TITLE
Mavlink signing test [DO NOT MERGE]

### DIFF
--- a/src/comm/MAVLinkProtocol.cc
+++ b/src/comm/MAVLinkProtocol.cc
@@ -254,8 +254,7 @@ void MAVLinkProtocol::receiveBytes(LinkInterface* link, QByteArray b)
 //                        memcpy(signing.secret_key, setupSigning.secret_key, 32);
                         memcpy(signing.secret_key, mavlink_secret_key.secret_key, 32);
                         signing.link_id = (uint8_t)mavlinkChannel;
-//                        signing.timestamp = setupSigning.initial_timestamp;
-                        signing.timestamp = mavlink_secret_key.timestamp;
+                        signing.timestamp = setupSigning.initial_timestamp;
                         signing.flags = MAVLINK_SIGNING_FLAG_SIGN_OUTGOING;
                         signing.accept_unsigned_callback = accept_unsigned_callback;
 


### PR DESCRIPTION
@DonLakeFlyer I did found one issue with the mavlink status, because in order to parse a signed message it needs to able to access the `signing` and `signing_streams`. 
I'm not so familiar with the QGC code, it could be that my change could cause some problem if the multiple threads try to access the `signing_streams` variable.