### PR TITLE
ArduPilot: Cleanup Servo Outputs page

### DIFF
--- a/src/AutoPilotPlugins/APM/APMServoComponent.qml
+++ b/src/AutoPilotPlugins/APM/APMServoComponent.qml
@@ -62,24 +62,23 @@ SetupPage {
                     columnSpacing: ScreenTools.defaultFontPixelWidth * 2
 
                     // --- Headers (all explicitly in row 0) -----------------
-                    QGCLabel { text: qsTr("Servo");         font.bold: true; Layout.row: 0; Layout.column: 0 }
+                    QGCLabel { text: "";         Layout.row: 0; Layout.column: 0; Layout.alignment: Qt.AlignHCenter }
                     QGCLabel {
                         text: qsTr("Position")
-                        font.bold: true
                         Layout.row: 0
                         Layout.column: 1
-                        Layout.preferredWidth: _positionBarWidth
-                        Layout.fillWidth: false
+                        Layout.alignment: Qt.AlignHCenter
                     }
-                    QGCLabel { text: qsTr("Function");      font.bold: true; Layout.row: 0; Layout.column: 2 }
-                    QGCLabel { text: qsTr("Min");           font.bold: true; Layout.row: 0; Layout.column: 3 }
-                    QGCLabel { text: qsTr("Trim");          font.bold: true; Layout.row: 0; Layout.column: 4 }
-                    QGCLabel { text: qsTr("Max");           font.bold: true; Layout.row: 0; Layout.column: 5 }
-                    QGCLabel { text: qsTr("Reversed");      font.bold: true; Layout.row: 0; Layout.column: 6 }
+                    QGCLabel { text: qsTr("Function");      Layout.row: 0; Layout.column: 2; Layout.alignment: Qt.AlignHCenter }
+                    QGCLabel { text: qsTr("Min");           Layout.row: 0; Layout.column: 3; Layout.alignment: Qt.AlignHCenter }
+                    QGCLabel { text: qsTr("Trim");          Layout.row: 0; Layout.column: 4; Layout.alignment: Qt.AlignHCenter }
+                    QGCLabel { text: qsTr("Max");           Layout.row: 0; Layout.column: 5; Layout.alignment: Qt.AlignHCenter }
+                    QGCLabel { text: qsTr("Reversed");      Layout.row: 0; Layout.column: 6; Layout.alignment: Qt.AlignHCenter }
 
                     // --- Column 0: Servo number ----------------------------
                     Repeater {
                         model: _maxServos
+
                         QGCLabel {
                             text:          index + 1
                             visible:       servoExists(index + 1)
@@ -92,6 +91,7 @@ SetupPage {
                     Repeater {
                         id: positionRepeater
                         model: _maxServos
+
                         Item {
                             readonly property int _servoIndex: index + 1
                             readonly property var _minFact:  getFact("SERVO" + _servoIndex + "_MIN")
@@ -173,6 +173,7 @@ SetupPage {
                     // --- Column 2: Function --------------------------------
                     Repeater {
                         model: _maxServos
+
                         FactComboBox {
                             fact:           getFact("SERVO" + (index + 1) + "_FUNCTION")
                             indexModel:     false
@@ -186,8 +187,9 @@ SetupPage {
                     // --- Column 3: Min ---------------------------------------
                     Repeater {
                         model: _maxServos
+
                         RowLayout {
-                            spacing:       ScreenTools.defaultFontPixelWidth
+                            spacing:       ScreenTools.defaultFontPixelWidth / 2
                             visible:       servoExists(index + 1)
                             Layout.row:    index + 1
                             Layout.column: 3
@@ -213,6 +215,12 @@ SetupPage {
 
                             QGCButton {
                                 text: "-"
+                                leftPadding: 0
+                                rightPadding: 0
+                                topPadding: 0
+                                bottomPadding: 0
+                                Layout.preferredWidth:  ScreenTools.implicitTextFieldHeight
+                                Layout.preferredHeight: ScreenTools.implicitTextFieldHeight
                                 onPressed: {
                                     if (!spFact) {
                                         _repeatDir = 0
@@ -231,6 +239,12 @@ SetupPage {
                             FactTextField { fact: spFact; showUnits: false; Layout.fillWidth: true }
                             QGCButton {
                                 text: "+"
+                                leftPadding: 0
+                                rightPadding: 0
+                                topPadding: 0
+                                bottomPadding: 0
+                                Layout.preferredWidth:  ScreenTools.implicitTextFieldHeight
+                                Layout.preferredHeight: ScreenTools.implicitTextFieldHeight
                                 onPressed: {
                                     if (!spFact) {
                                         _repeatDir = 0
@@ -252,8 +266,9 @@ SetupPage {
                     // --- Column 4: Trim --------------------------------------
                     Repeater {
                         model: _maxServos
+
                         RowLayout {
-                            spacing:       ScreenTools.defaultFontPixelWidth
+                            spacing:       ScreenTools.defaultFontPixelWidth / 2
                             visible:       servoExists(index + 1)
                             Layout.row:    index + 1
                             Layout.column: 4
@@ -279,6 +294,12 @@ SetupPage {
 
                             QGCButton {
                                 text: "-"
+                                leftPadding: 0
+                                rightPadding: 0
+                                topPadding: 0
+                                bottomPadding: 0
+                                Layout.preferredWidth:  ScreenTools.implicitTextFieldHeight
+                                Layout.preferredHeight: ScreenTools.implicitTextFieldHeight
                                 onPressed: {
                                     if (!spFact) {
                                         _repeatDir = 0
@@ -297,6 +318,12 @@ SetupPage {
                             FactTextField { fact: spFact; showUnits: false; Layout.fillWidth: true }
                             QGCButton {
                                 text: "+"
+                                leftPadding: 0
+                                rightPadding: 0
+                                topPadding: 0
+                                bottomPadding: 0
+                                Layout.preferredWidth:  ScreenTools.implicitTextFieldHeight
+                                Layout.preferredHeight: ScreenTools.implicitTextFieldHeight
                                 onPressed: {
                                     if (!spFact) {
                                         _repeatDir = 0
@@ -318,8 +345,9 @@ SetupPage {
                     // --- Column 5: Max ---------------------------------------
                     Repeater {
                         model: _maxServos
+
                         RowLayout {
-                            spacing:       ScreenTools.defaultFontPixelWidth
+                            spacing:       ScreenTools.defaultFontPixelWidth / 2
                             visible:       servoExists(index + 1)
                             Layout.row:    index + 1
                             Layout.column: 5
@@ -345,6 +373,12 @@ SetupPage {
 
                             QGCButton {
                                 text: "-"
+                                leftPadding: 0
+                                rightPadding: 0
+                                topPadding: 0
+                                bottomPadding: 0
+                                Layout.preferredWidth:  ScreenTools.implicitTextFieldHeight
+                                Layout.preferredHeight: ScreenTools.implicitTextFieldHeight
                                 onPressed: {
                                     if (!spFact) {
                                         _repeatDir = 0
@@ -363,6 +397,12 @@ SetupPage {
                             FactTextField { fact: spFact; showUnits: false; Layout.fillWidth: true }
                             QGCButton {
                                 text: "+"
+                                leftPadding: 0
+                                rightPadding: 0
+                                topPadding: 0
+                                bottomPadding: 0
+                                Layout.preferredWidth:  ScreenTools.implicitTextFieldHeight
+                                Layout.preferredHeight: ScreenTools.implicitTextFieldHeight
                                 onPressed: {
                                     if (!spFact) {
                                         _repeatDir = 0
@@ -384,11 +424,13 @@ SetupPage {
                     // --- Column 6: Reversed ---------------------------------
                     Repeater {
                         model: _maxServos
+
                         FactCheckBox {
                             fact:          getFact("SERVO" + (index + 1) + "_REVERSED")
                             visible:       servoExists(index + 1)
                             Layout.row:    index + 1
                             Layout.column: 6
+                            Layout.alignment: Qt.AlignHCenter
                         }
                     }
                 }


### PR DESCRIPTION
UI cleanup for the ArduPilot Servo Outputs setup page:

- Remove bold from column headers
- Center column headers and reversed checkboxes
- Size +/- buttons to match text field height (using ScreenTools.implicitTextFieldHeight)
- Use ScreenTools-based spacing in Min/Trim/Max row layouts